### PR TITLE
Add utility function to convert base32-encoded public key to IPv6 address

### DIFF
--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -1,9 +1,20 @@
-
+var crypto = require('crypto');
 var utilities = {},
 	validation = utilities.validation = {},
 	v6digitPattern = /^[0-9a-f]{0,4}$/,
 	BYTE_MAX = 255,
 	INT_MAX = 65535;
+
+var numForAscii = [
+  99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,
+  99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,
+  99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,
+   0, 1, 2, 3, 4, 5, 6, 7, 8, 9,99,99,99,99,99,99,
+  99,99,10,11,12,99,13,14,15,99,16,17,18,19,20,99,
+  21,22,23,24,25,26,27,28,29,30,31,99,99,99,99,99,
+  99,99,10,11,12,99,13,14,15,99,16,17,18,19,20,99,
+  21,22,23,24,25,26,27,28,29,30,31,99,99,99,99,99,
+];
 
 module.exports = utilities;
 
@@ -151,4 +162,66 @@ utilities.expand6 = function(ipv6) {
 		return item;
 	});
 	return digits.join(':');
+};
+
+/**
+ * Decodes a base32-encoded string into a BUffer
+ * @param {string} base32-encoded string
+ * @return {Buffer} the decoded input
+ */
+utilities.b32Decode = function(input) {
+	var output = [];
+	var outputIndex = 0;
+	var inputIndex = 0;
+	var nextByte = 0;
+	var bits = 0;
+
+	while (inputIndex < input.length) {
+		var o = input.charCodeAt(inputIndex);
+		if (o & 0x80) { throw new Error(); }
+		var b = numForAscii[o];
+		inputIndex++;
+		if (b > 31) { throw new Error("bad character " + input[inputIndex] + " in " + input); }
+
+		nextByte |= (b << bits);
+		bits += 5;
+
+		if (bits >= 8) {
+			output[outputIndex] = nextByte & 0xff;
+			outputIndex++;
+			bits -= 8;
+			nextByte >>= 8;
+		}
+	}
+
+	if (bits >= 5 || nextByte) {
+		throw new Error("bits is " + bits + " and nextByte is " + nextByte);
+	}
+
+	return new Buffer(output);
+};
+
+/**
+ * Converts a public key to an IPv6 address
+ * @param {string} base32-encoded public key
+ * @return {string} ipv6
+ */
+utilities.publicKeyToIPv6 = function(publicKey) {
+	var chunks, hexdigest;
+	var hash1 = crypto.createHash('sha512');
+	var hash2 = crypto.createHash('sha512');
+
+	// Strip off the ".k" at the end
+	publicKey = publicKey.substring(0, 52);
+
+	hash1.update(utilities.b32Decode(publicKey));
+	hash2.update(hash1.digest('binary'));
+
+	hexdigest = hash2.digest('hex').substring(0, 32);
+	chunks = [];
+	for (var j = 0; j < 32; j += 4) {
+		chunks.push(hexdigest.substring(j, j + 4));
+	}
+
+	return chunks.join(":");
 };


### PR DESCRIPTION
Added some code to be able to convert public keys to IP addresses. Some of the added code is from [cjdnsjs](https://github.com/ansuz/cjdnsjs), though, which has a GPL license. I think that means this project would have to use it, too.

The code specifically used is the base32 decode function in
https://github.com/ansuz/cjdnsjs/blob/master/scripts/keys/cjdb32.js
